### PR TITLE
chore: rethinkdb 2.4.10.post1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
     ],
-    install_requires=['rethinkdb==2.4.9'],
+    install_requires=['rethinkdb==2.4.10.post1'],
     extras_require={'test': test_deps},
     url='https://github.com/internetarchive/doublethink',
     author='Noah Levitt',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,11 +18,11 @@ limitations under the License.
 
 import doublethink
 import doublethink.cli
+import importlib.metadata
 import logging
 import sys
 import pytest
 import rethinkdb as rdb
-import pkg_resources
 
 r = rdb.RethinkDB()
 
@@ -50,10 +50,16 @@ def rr():
     assert result["dbs_created"] == 1
     return RethinkerForTesting(db="doublethink_test_db")
 
+def console_scripts():
+    return {
+        ep.name: ep
+        for ep in importlib.metadata.distribution("doublethink").entry_points
+        if ep.group == "console_scripts"
+    }
+
 def test_cli(capsys, rr):
-    entrypoint = pkg_resources.get_entry_map(
-            'doublethink')['console_scripts']['doublethink-purge-stale-services']
-    callable = entrypoint.resolve()
+    entrypoint = console_scripts()['doublethink-purge-stale-services']
+    callable = entrypoint.load()
     with pytest.raises(SystemExit) as exit:
         callable(['doublethink-purge-stale-services'])
     print(dir(exit))


### PR DESCRIPTION
This upgrades to rethinkdb-python 2.4.10.post1, which is so far the final release of this package. There are a few changes in this release, but the main one for us is that it no longer has a runtime dependency on distutils and hence works better with Python 3.12. I've run the tests and confirmed that, with the switch to `importlib` I applied here, the tests pass just fine on 3.12.